### PR TITLE
Update nan to version 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ notifications:
 
 node_js:
   - 0.12
+  - 4.0
 
 git:
   depth: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,8 @@ node_js:
 
 git:
   depth: 10
+
+sudo: false
+
+env:
+  - CC=clang CXX=clang++ npm_config_clang=1

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "event-kit": "^1.1.0",
-    "nan": "https://atom.io/download/atom-shell/nan-1.6.1.tgz"
+    "nan": "^2.0.0"
   },
   "scripts": {
     "prepublish": "grunt prepublish",

--- a/src/scrollbar-style-observer-mac.mm
+++ b/src/scrollbar-style-observer-mac.mm
@@ -3,27 +3,27 @@
 
 using namespace v8;
 
-void ScrollbarStyleObserver::Init(Handle<Object> target) {
-  NanScope();
-  Local<FunctionTemplate> newTemplate = NanNew<FunctionTemplate>(ScrollbarStyleObserver::New);
-  newTemplate->SetClassName(NanNew<String>("ScrollbarStyleObserver"));
+void ScrollbarStyleObserver::Init(Local<Object> target) {
+  Nan::HandleScope scope;
+  Local<FunctionTemplate> newTemplate = Nan::New<FunctionTemplate>(ScrollbarStyleObserver::New);
+  newTemplate->SetClassName(Nan::New<String>("ScrollbarStyleObserver").ToLocalChecked());
   newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
   Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
-  NODE_SET_METHOD(proto, "getPreferredScrollbarStyle", ScrollbarStyleObserver::GetPreferredScrollbarStyle);
-  target->Set(NanNew<String>("ScrollbarStyleObserver"), newTemplate->GetFunction());
+  Nan::SetMethod(proto, "getPreferredScrollbarStyle", ScrollbarStyleObserver::GetPreferredScrollbarStyle);
+  target->Set(Nan::New<String>("ScrollbarStyleObserver").ToLocalChecked(), newTemplate->GetFunction());
 }
 
 NODE_MODULE(scrollbar_style_observer, ScrollbarStyleObserver::Init)
 
 NAN_METHOD(ScrollbarStyleObserver::New) {
-  NanScope();
+  Nan::HandleScope scope;
 
-  Local<Function> callbackHandle = args[0].As<Function>();
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Local<Function> callbackHandle = info[0].As<Function>();
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   ScrollbarStyleObserver *observer = new ScrollbarStyleObserver(callback);
-  observer->Wrap(args.This());
-  NanReturnUndefined();
+  observer->Wrap(info.This());
+  return;
 }
 
 uv_loop_t *loop = uv_default_loop();
@@ -38,7 +38,7 @@ static void asyncSendHandler(uv_async_t *handle) {
   (static_cast<ScrollbarStyleObserver *>(handle->data))->HandleScrollbarStyleChanged();
 }
 
-ScrollbarStyleObserver::ScrollbarStyleObserver(NanCallback *callback) : callback(callback) {
+ScrollbarStyleObserver::ScrollbarStyleObserver(Nan::Callback *callback) : callback(callback) {
   uv_async_init(loop, &async, asyncSendHandler);
 
   CFNotificationCenterAddObserver(
@@ -60,11 +60,11 @@ void ScrollbarStyleObserver::HandleScrollbarStyleChanged() {
 }
 
 NAN_METHOD(ScrollbarStyleObserver::GetPreferredScrollbarStyle) {
-  NanScope();
+  Nan::HandleScope scope;
 
   if ([NSScroller preferredScrollerStyle] == NSScrollerStyleOverlay) {
-    NanReturnValue(NanNew<String>("overlay"));
+    info.GetReturnValue().Set(Nan::New<String>("overlay").ToLocalChecked());
   } else {
-    NanReturnValue(NanNew<String>("legacy"));
+    info.GetReturnValue().Set(Nan::New<String>("legacy").ToLocalChecked());
   }
 }

--- a/src/scrollbar-style-observer-non-mac.cc
+++ b/src/scrollbar-style-observer-non-mac.cc
@@ -23,30 +23,30 @@
 
 using namespace v8; // NOLINT
 
-void ScrollbarStyleObserver::Init(Handle<Object> target) {
-  NanScope();
-  Local<FunctionTemplate> newTemplate = NanNew<FunctionTemplate>(ScrollbarStyleObserver::New);
-  newTemplate->SetClassName(NanNew<String>("ScrollbarStyleObserver"));
+void ScrollbarStyleObserver::Init(Local<Object> target) {
+  Nan::HandleScope scope;
+  Local<FunctionTemplate> newTemplate = Nan::New<FunctionTemplate>(ScrollbarStyleObserver::New);
+  newTemplate->SetClassName(Nan::New<String>("ScrollbarStyleObserver").ToLocalChecked());
   newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
   Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
-  NODE_SET_METHOD(proto, "getPreferredScrollbarStyle", ScrollbarStyleObserver::GetPreferredScrollbarStyle);
-  target->Set(NanNew<String>("ScrollbarStyleObserver"), newTemplate->GetFunction());
+  Nan::SetMethod(proto, "getPreferredScrollbarStyle", ScrollbarStyleObserver::GetPreferredScrollbarStyle);
+  target->Set(Nan::New<String>("ScrollbarStyleObserver").ToLocalChecked(), newTemplate->GetFunction());
 }
 
 NODE_MODULE(scrollbar_style_observer, ScrollbarStyleObserver::Init)
 
 NAN_METHOD(ScrollbarStyleObserver::New) {
-  NanScope();
+  Nan::HandleScope scope;
 
-  Local<Function> callbackHandle = args[0].As<Function>();
-  NanCallback *callback = new NanCallback(callbackHandle);
+  Local<Function> callbackHandle = info[0].As<Function>();
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   ScrollbarStyleObserver *observer = new ScrollbarStyleObserver(callback);
-  observer->Wrap(args.This());
-  NanReturnUndefined();
+  observer->Wrap(info.This());
+  return;
 }
 
-ScrollbarStyleObserver::ScrollbarStyleObserver(NanCallback *callback) : callback(callback) {
+ScrollbarStyleObserver::ScrollbarStyleObserver(Nan::Callback *callback) : callback(callback) {
 }
 
 ScrollbarStyleObserver::~ScrollbarStyleObserver() {
@@ -57,6 +57,6 @@ void ScrollbarStyleObserver::HandleScrollbarStyleChanged() {
 }
 
 NAN_METHOD(ScrollbarStyleObserver::GetPreferredScrollbarStyle) {
-  NanScope();
-  NanReturnValue(NanNew<String>("legacy"));
+  Nan::HandleScope scope;
+  info.GetReturnValue().Set(Nan::New<String>("legacy").ToLocalChecked());
 }

--- a/src/scrollbar-style-observer.h
+++ b/src/scrollbar-style-observer.h
@@ -26,18 +26,18 @@
 
 using namespace v8;  // NOLINT
 
-class ScrollbarStyleObserver : public node::ObjectWrap {
+class ScrollbarStyleObserver : public Nan::ObjectWrap {
  public:
-  static void Init(Handle<Object> target);
+  static void Init(Local<Object> target);
   void HandleScrollbarStyleChanged();
 
  private:
-  explicit ScrollbarStyleObserver(NanCallback *callback);
+  explicit ScrollbarStyleObserver(Nan::Callback *callback);
   ~ScrollbarStyleObserver();
   static NAN_METHOD(New);
   static NAN_METHOD(GetPreferredScrollbarStyle);
 
-  NanCallback *callback;
+  Nan::Callback *callback;
 };
 
 #endif  // SRC_SCROLLBAR_STYLE_OBSERVER_H_


### PR DESCRIPTION
This PR updates the nan package dependency from 1.6.1 to 2.0.0. This is the result of running https://gist.github.com/thlorenz/7e9d8ad15566c99fd116 on the relevant source files.